### PR TITLE
Add cleanup to each test suite

### DIFF
--- a/src/bar.spec.ts
+++ b/src/bar.spec.ts
@@ -1,6 +1,13 @@
 import { add } from './bar';
 
 describe('Bar', () => {
+    afterEach(() => {
+        add.expirations.forEach((expiration) =>
+            clearTimeout(expiration.timeoutId)
+        );
+        add.expirations.length = 0;
+    });
+
     describe('When adding two numbers', () => {
         it('it adds the numbers', async () => {
             await expect(add(3, 2)).resolves.toEqual(5);

--- a/src/foo.spec.ts
+++ b/src/foo.spec.ts
@@ -1,6 +1,13 @@
 import { subtract } from './foo';
 
 describe('Bar', () => {
+    afterEach(() => {
+        subtract.expirations.forEach((expiration) =>
+            clearTimeout(expiration.timeoutId)
+        );
+        subtract.expirations.length = 0;
+    });
+
     describe('When subtracting two numbers', () => {
         it('it subtracts the numbers', async () => {
             await expect(subtract(3, 2)).resolves.toEqual(1);


### PR DESCRIPTION
Example of adding cleanup to tests to prevent the `jest` warning.